### PR TITLE
Use GitHub Actions to automatically build binaries for amd64 and arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build tg-antispam binaries
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Verify Go modules
+      run: go mod verify
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Build Linux AMD64
+      run: |
+        GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o tg-antispam-linux-amd64 ./cmd/main
+
+    - name: Build Linux ARM64
+      run: |
+        GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o tg-antispam-linux-arm64 ./cmd/main
+
+    - name: List binaries
+      run: ls -la tg-antispam-*
+
+    - name: Upload binaries as artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: tg-antispam-binaries-${{ github.ref_name }}
+        path: |
+          tg-antispam-linux-amd64
+          tg-antispam-linux-arm64
+        retention-days: 90
+
+    - name: Create Release and Upload Assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          tg-antispam-linux-amd64
+          tg-antispam-linux-arm64
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use GitHub Actions to automatically build binaries for amd64 and arm64.