### PR TITLE
Bot status change updates

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -50,6 +50,9 @@ func main() {
 		logger.Info("Database support is disabled. Repositories will not be initialized.")
 	}
 
+	// Start the cache cleanup goroutine regardless of DB status
+    service.StartCacheCleanup()
+	
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/handler/setup.go
+++ b/internal/handler/setup.go
@@ -36,8 +36,6 @@ func Initialize(cfg *config.Config) {
 
 // SetupMessageHandlers configures all bot message and update handlers
 func SetupMessageHandlers(bh *th.BotHandler, bot *telego.Bot) {
-	service.InitRepositories()
-
 	// 启动状态监控
 	StartStatusMonitoring()
 

--- a/internal/models/group_info.go
+++ b/internal/models/group_info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"tg-antispam/internal/logger"
 )
 
 // GroupInfo represents group information and settings
@@ -60,4 +61,20 @@ func (g *GroupInfoManager) RemoveGroupInfo(groupID int64) {
 	g.GroupInfoMapMu.Lock()
 	defer g.GroupInfoMapMu.Unlock()
 	delete(g.GroupInfoMap, groupID)
+}
+
+// ResetUserCache clears only the in-memory cache entries where GroupID > 0 (representing users).
+func (g *GroupInfoManager) ResetUserCache() {
+    g.GroupInfoMapMu.Lock()
+    defer g.GroupInfoMapMu.Unlock()
+    
+    removedCount := 0
+    // Iterate through the map and delete entries with GroupID > 0
+    for groupID := range g.GroupInfoMap {
+        if groupID > 0 {
+            delete(g.GroupInfoMap, groupID)
+            removedCount++
+        }
+    }
+    logger.Infof("User entries (group_id > 0) removed from GroupInfo cache: %d", removedCount)
 }

--- a/internal/service/group_service.go
+++ b/internal/service/group_service.go
@@ -80,30 +80,38 @@ func GetGroupInfo(bot *telego.Bot, groupID int64, create bool) *models.GroupInfo
 		}
 
 		groupInfo.AdminID, groupInfo.IsAdmin = GetBotPromoterID(bot, groupID)
+		
+		// Only update the database if the GroupID represents a group (GroupID < 0)
+		if groupRepository != nil {
+			if err := groupRepository.CreateOrUpdateGroupInfo(groupInfo); err != nil {
+				logger.Warningf("Error saving group info to database for groupID %d: %v", groupID, err)
+			}
+		}
+		
+	} else {
+	    // For user records (GroupID > 0), only add to cache, do not save to DB.
+		logger.Debugf("Skipped saving user record (group_id > 0) to database during GetGroupInfo: %d", groupID)
 	}
 
 	logger.Infof("Group info created: %+v", groupInfo)
 
 	groupInfoManager.AddGroupInfo(groupInfo)
 
-	if groupRepository != nil {
-		if err := groupRepository.CreateOrUpdateGroupInfo(groupInfo); err != nil {
-			logger.Warningf("Error saving group info to database: %v", err)
-		}
-	}
-
 	return groupInfo
 }
 
 // UpdateGroupInfo updates group information in cache and database
+// For records representing users (GroupID > 0), it only updates the cache, not the database.
 func UpdateGroupInfo(groupInfo *models.GroupInfo) {
 	groupInfoManager.AddGroupInfo(groupInfo)
 
-	if groupRepository != nil {
-		if err := groupRepository.CreateOrUpdateGroupInfo(groupInfo); err != nil {
-			logger.Warningf("Error updating group info in database: %v", err)
-		}
-	}
+    if groupRepository != nil && groupInfo.GroupID < 0 {
+        if err := groupRepository.CreateOrUpdateGroupInfo(groupInfo); err != nil {
+            logger.Warningf("Error updating group info in database for groupID %d: %v", groupInfo.GroupID, err)
+        }
+    } else if groupRepository != nil && groupInfo.GroupID > 0 {
+        logger.Debugf("Skipped updating database for user record (group_id > 0): %d", groupInfo.GroupID)
+    }
 }
 
 // DeleteGroupInfo removes group information from both cache and database
@@ -116,6 +124,7 @@ func DeleteGroupInfo(groupID int64) error {
     if groupRepository != nil {
         if err := groupRepository.DeleteGroupInfo(groupID); err != nil {
             logger.Warningf("Error deleting group info from database for groupID %d: %v", groupID, err)
+            // 如果数据库删除失败，可以选择是否回滚缓存删除（这里不回滚）
             return err
         }
         logger.Infof("Deleted group info for groupID: %d from database", groupID)

--- a/internal/service/group_service.go
+++ b/internal/service/group_service.go
@@ -106,6 +106,26 @@ func UpdateGroupInfo(groupInfo *models.GroupInfo) {
 	}
 }
 
+// DeleteGroupInfo removes group information from both cache and database
+func DeleteGroupInfo(groupID int64) error {
+    // 1. Remove from memory cache
+    groupInfoManager.RemoveGroupInfo(groupID)
+    logger.Infof("Removed group info for groupID: %d from cache", groupID)
+
+    // 2. Remove from database (if repository is available)
+    if groupRepository != nil {
+        if err := groupRepository.DeleteGroupInfo(groupID); err != nil {
+            logger.Warningf("Error deleting group info from database for groupID %d: %v", groupID, err)
+            return err
+        }
+        logger.Infof("Deleted group info for groupID: %d from database", groupID)
+    } else {
+        logger.Warning("Database repository is not available, only removed from cache.")
+    }
+
+    return nil
+}
+
 func GetBotPromoterID(bot *telego.Bot, chatID int64) (int64, bool) {
 	// 创建带超时的context
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
1. Fix: Bug in bot status updates
A bug where changes to the bot’s permissions (e.g., when promoted to admin) were not updating the `group_infos.is_admin` field and cache.
2. Add: Business logic for when the bot is removed, kicked, or banned
Logic to remove the corresponding record from `group_infos` and clear related cache when the bot leaves, is kicked, or banned.